### PR TITLE
Fixed incorrect slash in update-runtime.sh

### DIFF
--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-bin\micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y
+bin/micromamba create --no-shortcuts -r conda -n linux -f environment.yaml -y


### PR DESCRIPTION
update-runtime.sh uses a backslash when attempting to start bin/microconda.  This PR fixes it so the environment is properly activated.